### PR TITLE
Fixes for 1.4.5

### DIFF
--- a/plugin/controller.js
+++ b/plugin/controller.js
@@ -288,11 +288,11 @@
     };
 
     function getImagePath(image) {
-        return path.join(nconf.get('relative_path'), nconf.get('upload_url'), constants.UPLOAD_DIR, image);
+        return nodebb.plugins.hasListeners('filter:uploadImage') ? image : path.join(nconf.get('relative_path'), nconf.get('upload_url'), constants.UPLOAD_DIR, image);
     }
 
     function getUploadImagePath(fileName) {
-        return path.join(nconf.get('base_dir'), nconf.get('upload_path'), constants.UPLOAD_DIR, fileName);
+        return nodebb.plugins.hasListeners('filter:uploadImage') ? fileName : path.join(nconf.get('base_dir'), nconf.get('upload_path'), constants.UPLOAD_DIR, fileName);
     }
 
     function getValidFields(fields, object) {

--- a/plugin/controller.js
+++ b/plugin/controller.js
@@ -288,11 +288,12 @@
     };
 
     function getImagePath(image) {
-        return nodebb.plugins.hasListeners('filter:uploadImage') ? image : path.join(nconf.get('relative_path'), nconf.get('upload_url'), constants.UPLOAD_DIR, image);
+        return image.indexOf('http') !== -1 ? image : 
+            path.join(nconf.get('relative_path'), image.replace(path.join(nconf.get('base_dir'), 'public'), '')).replace(/\\/g, '/');
     }
 
     function getUploadImagePath(fileName) {
-        return nodebb.plugins.hasListeners('filter:uploadImage') ? fileName : path.join(nconf.get('base_dir'), nconf.get('upload_path'), constants.UPLOAD_DIR, fileName);
+        return path.join(nconf.get('base_dir'), nconf.get('upload_path'), constants.UPLOAD_DIR, fileName);
     }
 
     function getValidFields(fields, object) {

--- a/plugin/controller.js
+++ b/plugin/controller.js
@@ -168,6 +168,7 @@
                     }
 
                     next(null, {
+                        title: 'Awards',
                         awards     : awards,
                         breadcrumbs: helpers.buildBreadcrumbs([{text: 'Awards'}])
                     });

--- a/plugin/uploads.js
+++ b/plugin/uploads.js
@@ -101,7 +101,8 @@
     };
 
     Uploads.getUploadPath = function (fileName) {
-        return path.join(nconf.get('base_dir'), nconf.get('upload_path'), constants.UPLOAD_DIR, fileName);
+
+        return path.join(nconf.get('upload_path'), constants.UPLOAD_DIR, fileName);
     };
 
     Uploads.isLocalFile = function (file) {

--- a/plugin/uploads.js
+++ b/plugin/uploads.js
@@ -32,7 +32,7 @@
             constants.API_PATH,
             constants.PLUGIN_PATH,
             constants.IMAGE_SERVICE_PATH
-        );
+        ).replace(/\\/g, '/');
         var fileMiddleware = multer({storage: storage}).single('award');
 
         router.post(route, [fileMiddleware, middleware.applyCSRF, middleware.authenticate], function (req, res, next) {

--- a/plugin/uploads.js
+++ b/plugin/uploads.js
@@ -37,7 +37,7 @@
 
         router.post(route, [fileMiddleware, middleware.authenticate], function (req, res, next) {
             var saveDidComplete = function (error, file) {
-                var entityId = req.headers['x-ns-award-entity-id'];
+                var entityId = req.headers['x-ns-award-entity-id'] || 'newAwardId';
 
                 if (error) {
                     return res.status(500).json(error);
@@ -47,7 +47,6 @@
                     if (err) {
                         return res.status(500).json(err);
                     }
-
                     files[entityId] = file;
 
                     res.json({

--- a/plugin/uploads.js
+++ b/plugin/uploads.js
@@ -35,7 +35,7 @@
         ).replace(/\\/g, '/');
         var fileMiddleware = multer({storage: storage}).single('award');
 
-        router.post(route, [fileMiddleware, middleware.applyCSRF, middleware.authenticate], function (req, res, next) {
+        router.post(route, [fileMiddleware, middleware.authenticate], function (req, res, next) {
             var saveDidComplete = function (error, file) {
                 var entityId = req.headers['x-ns-award-entity-id'];
 

--- a/public/templates/partials/awards_profile.tpl
+++ b/public/templates/partials/awards_profile.tpl
@@ -1,5 +1,5 @@
 <!-- IF awards.length -->
-<div class="panel panel-default">
+<div class="awards-panel panel panel-default">
     <div class="panel-body">
 
         <ul class="profile-awards">

--- a/style/profile.less
+++ b/style/profile.less
@@ -14,14 +14,6 @@
       width: @aw-award-preview-size;
       margin: @aw-base-rhythm
     }
-    
-    .award-image img {
-      min-width: 40px;
-      min-height: 40px;
-      margin-right: 20px;
-      margin-left: 15px;
-      padding-top: 5px;
-    }
   }
 }
 
@@ -40,6 +32,11 @@
       display: block;
       max-width: @perfect-size;
       height: auto;
+      min-width: 40px;
+      min-height: 40px;
+      margin-right: 20px;
+      margin-left: 15px;
+      padding-top: 5px;
     }
   }
 

--- a/style/profile.less
+++ b/style/profile.less
@@ -13,6 +13,11 @@
       align-self: center;
       width: @aw-award-preview-size;
       margin: @aw-base-rhythm;
+      min-width: 40px;
+      min-height: 40px;
+      margin-right: 20px;
+      margin-left: 15px;
+      padding-top: 5px;
     }
   }
 }

--- a/style/profile.less
+++ b/style/profile.less
@@ -12,7 +12,10 @@
       flex: 0 1 auto;
       align-self: center;
       width: @aw-award-preview-size;
-      margin: @aw-base-rhythm;
+      margin: @aw-base-rhythm
+    }
+    
+    .award-image img {
       min-width: 40px;
       min-height: 40px;
       margin-right: 20px;


### PR DESCRIPTION
I confirmed on two environments (nix/windows) with these changes that the plugin now works on 1.4.5. 

ACP CSS seems to still be broken (as well as the image path in ACP only), but everything else is still functional. The front end works perfectly (profile page + /awards page).

I wouldn't blind merge this though, as I think a couple of things could be fixed on the react side (see this hack: https://github.com/NicolasSiver/nodebb-plugin-ns-awards/commit/cea3c91d51048a621d49c9f42b85ada29de83d41) instead. I'm not actually sure what I'm doing in that particular commit but it fixed image uploading.