### PR TITLE
fix: filter:account/profile.build hook passes in different object

### DIFF
--- a/plugin/filters.js
+++ b/plugin/filters.js
@@ -6,17 +6,17 @@
 
     /**
      * Hook to render a user profile.
-     * 'userData' will be used as payload in hook handler.
+     * 'templateData' will be used as payload in hook handler.
      *
-     * @param {object} payload structure {userData: userData, uid: callerUID}
+     * @param {object} payload structure { req: req, res: res, templateData: userData}
      * @param {function} callback
      */
     Filter.account = function (payload, callback) {
-        controller.getAccountWithRewards(payload.userData, function (error, account) {
+        controller.getAccountWithRewards(payload.templateData, function (error, templateData) {
             if (error) {
                 return callback(error);
             }
-            payload.userData = account;
+            payload.templateData = templateData;
             callback(null, payload);
         });
     };


### PR DESCRIPTION
filter:account/profile.build is passed an object with req, res and templateData. Template data has the user info. Without this change the code crashes with 

```
TypeError: Cannot read properties of undefined (reading 'uid')
    at /home/saas/nodebb/node_modules/nodebb-plugin-ns-awards/plugin/controller.js:193:54
    at nextTask (/home/saas/nodebb/node_modules/async/dist/async.js:5789:13)
    at next (/home/saas/nodebb/node_modules/async/dist/async.js:5797:13)
    at /home/saas/nodebb/node_modules/async/dist/async.js:327:20
    at Settings.get (/home/saas/nodebb/node_modules/nodebb-plugin-ns-awards/plugin/settings.js:60:16)
    at /home/saas/nodebb/node_modules/async/dist/async.js:53:33
    at nextTask (/home/saas/nodebb/node_modules/async/dist/async.js:5789:13)
    at Object.waterfall (/home/saas/nodebb/node_modules/async/dist/async.js:5800:9)
    at Object.awaitable [as waterfall] (/home/saas/nodebb/node_modules/async/dist/async.js:211:32)
    at Object.Controller.getAccountWithRewards (/home/saas/nodebb/node_modules/nodebb-plugin-ns-awards/plugin/controller.js:186:15)
    at Object.Filter.account [as method] (/home/saas/nodebb/node_modules/nodebb-plugin-ns-awards/plugin/filters.js:15:20)
    at /home/saas/nodebb/src/plugins/hooks.js:171:29

```